### PR TITLE
Cardinal Points Grasp - Type Top Grasp

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -441,14 +441,23 @@ class GrasperModule : public RFModule, public rpc_IDL {
             auto candidates_ = candidates;
             for (auto& c:candidates_) {
                 auto& T = get<2>(c);
-                const auto x = T.getCol(3).subVector(0, 2);
-                const auto axis_x = (sqCenter - x) / norm(sqCenter - x);
-                const Vector axis_y{0., 0., -1.};
+                const auto p = T.getCol(3).subVector(0, 2);
+                const auto axis_x = (sqCenter - p) / norm(sqCenter - p);
+                // take a generic vector normal to axis_x
+                Vector axis_y;
+                if (abs(axis_x[0]) > .001) {
+                    axis_y = Vector{-axis_x[1] / axis_x[0], 1., 0.};
+                } else if (abs(axis_x[1]) > .001) {
+                    axis_y = Vector{1., -axis_x[0] / axis_x[1], 0.};
+                } else {
+                    axis_y = Vector{0., 1., -axis_x[1] / axis_x[2]};
+                }
+                axis_y /= norm(axis_y);
                 const auto axis_z = cross(axis_x, axis_y);
                 T.setSubcol(axis_x, 0, 0);
                 T.setSubcol(axis_y, 0, 1);
                 T.setSubcol(axis_z, 0, 2);
-                T.setSubcol(x, 0, 3);
+                T.setSubcol(p, 0, 3);
             }
             viewer->showCandidates(candidates_);
         }

--- a/src/viewer.h
+++ b/src/viewer.h
@@ -294,7 +294,7 @@ public:
     }
 
     /**************************************************************************/
-    void showCandidates(const std::vector<cardinal_points_grasp::ranked_candidates>& candidates) {
+    void showCandidates(const std::vector<cardinal_points_grasp::rankable_candidate>& candidates) {
         std::lock_guard<std::mutex> lck(mtx);
         if (!vtk_arrows_actors.empty()) {
             for (auto vtk_actor:vtk_arrows_actors) {


### PR DESCRIPTION
This PR introduces top-grasps capability.

We check for:
1. Size of the SW wrt to pre-grasp aperture.
1. Height of the object wrt fingers max length.
1. In case we have similar quality measures for the best side and the best top grasp, then we enforce that candidate closer to the COG.

No animation available since we still have to integrate the new small object provided in #17.

closes #14 