### PR TITLE
Use GHCR in lieu of Docker Hub

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: pattacini/icub-gazebo-grasping-sandbox:latest
+image: ghcr.io/robotology/icub-gazebo-grasping-sandbox:1.0
 ports:
 - port: 6080
   onOpen: notify

--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -2,13 +2,13 @@
 ==========================================
 
 To run the sandbox locally using [Docker](https://www.docker.com), go through the following steps:
-1. Pull the docker image (⚠ you may need to [authenticate to GitHub Packages][1] beforehand):
+1. Pull the docker image:
     ```sh
-    $ docker pull docker.pkg.github.com/robotology/icub-gazebo-grasping-sandbox/gitpod:{tag}
+    $ docker pull ghcr.io/robotology/icub-gazebo-grasping-sandbox:{tag}
     ```
 1. Launch the container:
     ```sh
-    $ docker run -it --rm -p 6080:6080 --user gitpod docker.pkg.github.com/robotology/icub-gazebo-grasping-sandbox/gitpod:{tag}
+    $ docker run -it --rm -p 6080:6080 --user gitpod ghcr.io/robotology/icub-gazebo-grasping-sandbox:{tag}
     ```
 1. From within the container shell, launch the following scripts:
     ```sh
@@ -30,4 +30,3 @@ To run the sandbox locally using [Docker](https://www.docker.com), go through th
    ```
 1. Once done, from the container shell press **CTRL+D**.
 
-[1]: https://docs.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-docker-for-use-with-github-packages#authenticating-to-github-packages


### PR DESCRIPTION
We can now officially pull images from [GitHub Container Registry][1] using **anonymous access** ✨ 
Gitpod goes along with it gracefully 👍🏻 

cc @traversaro @xEnVrE @vtikha 

[1]: https://github.blog/2020-09-01-introducing-github-container-registry/