### PR TITLE
Update Dockerfile to the use of Ubuntu 2022.04

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -51,9 +51,9 @@ RUN git clone https://github.com/robotology/robotology-superbuild.git --depth 1 
     robotology-superbuild/scripts/install_apt_dependencies.sh
     
 RUN sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list' && \
-    wget https://packages.osrfoundation.org/gazebo.key -O - | apt-key add - && \
+    wget https://packages.osrfoundation.org/gazebo.key -O - | tee /etc/apt/trusted.gpg.d/gazebo.asc && \
     apt update && \
-    apt install -y libcgal-dev gazebo11 libgazebo11-dev
+    apt install -y libcgal-dev gazebo libgazebo-dev
 
 # Install VTK
 RUN git clone https://github.com/Kitware/VTK.git --depth 1 --branch v9.1.0 && \


### PR DESCRIPTION
This PR adapts the installation of `gazebo` to the use of Ubuntu 2022.04.

cc @traversaro 