### PR TITLE
Update to use `VNC` alongside with Ubuntu 2022.04

### DIFF
--- a/dockerfiles/start-vnc-session.sh
+++ b/dockerfiles/start-vnc-session.sh
@@ -1,6 +1,6 @@
-pkill -9 -f "vnc" && pkill -9 -f "xf" && sudo pkill -9 Xorg
+pkill -9 -f "novnc" && sudo pkill -9 x11vnc && pkill -9 -f "xf" && sudo pkill -9 Xorg
 sudo rm -f /tmp/.X1-lock
-sudo nohup X ${DISPLAY} -config /etc/X11/xorg.conf > /dev/null 2>&1 &
-nohup startxfce4 > /dev/null 2>&1 &
-nohup x11vnc -localhost -display ${DISPLAY} -N -forever -shared -bg > /dev/null 2>&1
-nohup /opt/novnc/utils/novnc_proxy --web /opt/novnc --vnc localhost:5901 --listen 6080 > /dev/null 2>&1 &
+sudo X ${DISPLAY} -config /etc/X11/xorg.conf > /dev/null 2>&1 & disown
+startxfce4 > /dev/null 2>&1 & disown
+sudo x11vnc -localhost -display ${DISPLAY} -N -forever -shared > /dev/null 2>&1 & disown
+/opt/novnc/utils/novnc_proxy --web /opt/novnc --vnc localhost:5901 --listen 6080 > /dev/null 2>&1 & disown


### PR DESCRIPTION
This PR updates the operations needed to launch VNC-related services on Ubuntu 2022.04.

cc @traversaro 