### PR TITLE
Update to use XFCE4 alongside with Ubuntu 2022.04

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -20,7 +20,8 @@ RUN locale-gen en_US.UTF-8
 
 # Install graphics
 RUN apt install -y xfce4 xfce4-goodies xserver-xorg-video-dummy xserver-xorg-legacy x11vnc firefox && \
-    apt remove -y xfce4-power-manager light-locker && \
+    apt remove -y xfce4-power-manager xfce4-screensaver light-locker && \
+    apt autoremove -y && \
     sed -i 's/allowed_users=console/allowed_users=anybody/' /etc/X11/Xwrapper.config
 COPY xorg.conf /etc/X11/xorg.conf
 RUN dos2unix /etc/X11/xorg.conf


### PR DESCRIPTION
This PR removes explicitly the screensaver, which causes the remote connection to get stuck after a while.

cc @traversaro 