### PR TITLE
`VTK` and `find-superquadric` delegated to `superbuild`

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -37,7 +37,10 @@ RUN apt install -y magic-wormhole
 RUN git clone https://github.com/novnc/noVNC.git /opt/novnc && \
     git clone https://github.com/novnc/websockify /opt/novnc/utils/websockify && \
     echo "<html><head><meta http-equiv=\"Refresh\" content=\"0; url=vnc.html?autoconnect=true&reconnect=true&reconnect_delay=1000&resize=scale&quality=9\"></head></html>" > /opt/novnc/index.html
-   
+
+# Install PCL and VTK
+RUN apt install -y libpcl-dev
+
 # Select options
 ARG ROBOTOLOGY_SUPERBUILD_RELEASE
 ARG BUILD_TYPE

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -38,7 +38,7 @@ RUN git clone https://github.com/novnc/noVNC.git /opt/novnc && \
     git clone https://github.com/novnc/websockify /opt/novnc/utils/websockify && \
     echo "<html><head><meta http-equiv=\"Refresh\" content=\"0; url=vnc.html?autoconnect=true&reconnect=true&reconnect_delay=1000&resize=scale&quality=9\"></head></html>" > /opt/novnc/index.html
 
-# Install PCL and VTK
+# Install PCL and VTK (a dependency for PCL)
 RUN apt install -y libpcl-dev
 
 # Select options

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -56,34 +56,17 @@ RUN sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb
     apt update && \
     apt install -y libcgal-dev gazebo libgazebo-dev
 
-# Install VTK
-RUN git clone https://github.com/Kitware/VTK.git --depth 1 --branch v9.1.0 && \
-    cd VTK && mkdir build && cd build && \
-    cmake .. \
-    -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
-    -DBUILD_TESTING=OFF && \
-    make install && \
-    cd ../.. && rm -Rf VTK
-
 # Build robotology-superbuild
 RUN cd robotology-superbuild && mkdir build && cd build && \
     cmake .. \
           -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
           -DYCM_EP_INSTALL_DIR=${ROBOTOLOGY_SUPERBUILD_INSTALL_DIR} \
           -DROBOTOLOGY_ENABLE_CORE:BOOL=ON \
-          -DROBOTOLOGY_USES_GAZEBO:BOOL=ON && \
+          -DROBOTOLOGY_ENABLE_GRASPING:BOOL=ON \
+          -DROBOTOLOGY_USES_GAZEBO:BOOL=ON \
+          -DROBOTOLOGY_USES_PCL_AND_VTK:BOOL=ON && \
     make && \
     cd ../.. && rm -Rf robotology-superbuild
-
-# Build find-superquadric
-RUN git clone https://github.com/robotology/find-superquadric.git --depth 1 && \
-    cd find-superquadric && mkdir build && cd build && \
-    cmake .. \
-    -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
-    -DCMAKE_PREFIX_PATH=${ROBOTOLOGY_SUPERBUILD_INSTALL_DIR} \
-    -DCMAKE_INSTALL_PREFIX=${ROBOTOLOGY_SUPERBUILD_INSTALL_DIR} && \
-    make install && \
-    cd ../.. && rm -Rf find-superquadric
 
 # Clean up git configuration
 RUN git config --global --unset-all user.name && \

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -38,9 +38,6 @@ RUN git clone https://github.com/novnc/noVNC.git /opt/novnc && \
     git clone https://github.com/novnc/websockify /opt/novnc/utils/websockify && \
     echo "<html><head><meta http-equiv=\"Refresh\" content=\"0; url=vnc.html?autoconnect=true&reconnect=true&reconnect_delay=1000&resize=scale&quality=9\"></head></html>" > /opt/novnc/index.html
 
-# Install PCL and VTK (a dependency for PCL)
-RUN apt install -y libpcl-dev
-
 # Select options
 ARG ROBOTOLOGY_SUPERBUILD_RELEASE
 ARG BUILD_TYPE
@@ -57,7 +54,7 @@ RUN git clone https://github.com/robotology/robotology-superbuild.git --depth 1 
 RUN sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list' && \
     wget https://packages.osrfoundation.org/gazebo.key -O - | tee /etc/apt/trusted.gpg.d/gazebo.asc && \
     apt update && \
-    apt install -y libcgal-dev gazebo libgazebo-dev
+    apt install -y  libpcl-dev libcgal-dev gazebo libgazebo-dev
 
 # Build robotology-superbuild
 RUN cd robotology-superbuild && mkdir build && cd build && \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,12 +7,16 @@
 
 find_package(YARP REQUIRED COMPONENTS os dev sig math)
 find_package(ICUB REQUIRED COMPONENTS iKin)
+
+set(CMAKE_MODULE_PATH_BAK ${CMAKE_MODULE_PATH})
+find_package(Gazebo REQUIRED)
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH_BAK})
+
 find_package(VTK REQUIRED)
 message (STATUS "VTK_VERSION: ${VTK_VERSION}")
 if (VTK_VERSION VERSION_LESS "8.90.0")
   include(${VTK_USE_FILE})
 endif()
-find_package(Gazebo REQUIRED)
 
 yarp_add_idl(IDL_GEN_FILES ${CMAKE_CURRENT_SOURCE_DIR}/rpc.thrift)
 add_executable(${PROJECT_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp ${IDL_GEN_FILES})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,7 @@
 find_package(YARP REQUIRED COMPONENTS os dev sig math)
 find_package(ICUB REQUIRED COMPONENTS iKin)
 
+# Gte around conflicts between VTK and Gazebo in Ubuntu 2022.04
 set(CMAKE_MODULE_PATH_BAK ${CMAKE_MODULE_PATH})
 find_package(Gazebo REQUIRED)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH_BAK})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,7 +8,7 @@
 find_package(YARP REQUIRED COMPONENTS os dev sig math)
 find_package(ICUB REQUIRED COMPONENTS iKin)
 
-# Gte around conflicts between VTK and Gazebo in Ubuntu 2022.04
+# Get around conflicts between VTK and Gazebo in Ubuntu 2022.04
 set(CMAKE_MODULE_PATH_BAK ${CMAKE_MODULE_PATH})
 find_package(Gazebo REQUIRED)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH_BAK})


### PR DESCRIPTION
Install `vtk` and `find-superquadric` via `superbuild`.
See https://github.com/robotology/robotology-superbuild/releases/tag/v2022.09.0.