### PR TITLE
Add ref to a work built on the cardinal points grasp algorithm used within the sandbox

### DIFF
--- a/docs/building-on-sandbox.md
+++ b/docs/building-on-sandbox.md
@@ -10,6 +10,7 @@ To include your method, just [open up a PR to change the table](https://github.c
 | SW Debug | [@pattacini](https://github.com/pattacini) | Debug an important SW patch to the versioning of kinematic chains | [robotology/icub-main/pull/839](https://github.com/robotology/icub-main/pull/839#issuecomment-1312760163) |
 | S4HRI | [@pattacini](https://github.com/pattacini) | Grasping of a cube applied on top of a setting designed in the context of a specific reaching experiment | [cht-iit/design-setup-bp/issues/23](https://github.com/cht-iit/design-setup-bp/issues/23) |
 | HW Design | [@vtikha](https://github.com/vtikha) [@vvasco](https://github.com/vvasco) | Design the Realsense holder for the iCub robot | [icub-tech-iit/design-holder-realsense](https://github.com/icub-tech-iit/design-holder-realsense) |
+| SW for Robotics | [@xenvre](https://github.com/xenvre) | Object handover with the iCub robot using the 6D object pose provided by the [ROFT](https://github.com/hsp-iit/ROFT) tracker | [hsp-iit/roft-samples](https://github.com/hsp-iit/roft-samples/blob/master/src/handover/include/cardinal_points_grasp.h) |
 
 ---
 


### PR DESCRIPTION
As discussed with @pattacini, I am opening this PR to add [hsp-iit/roft-samples](https://github.com/hsp-iit/roft-samples), based on [ROFT](https://github.com/hsp-iit/roft), in the list of works that took inspiration from this sandbox.

Specifically, the Cardinal Points Grasp algorithm, an implementation of which can be [found](https://github.com/robotology/icub-gazebo-grasping-sandbox/blob/master/src/cardinal_points_grasp.h) in this sandbox, has been used to implement an object "handover" demonstration with the iCub robot. The actual code, that is a bit different from the original implementation, can be found [here](https://github.com/hsp-iit/roft-samples/blob/master/src/handover/include/cardinal_points_grasp.h).

@pattacini not sure if the `Topic` field and the phrasing are ok. 