### PR TITLE
Update icub-grasp.xml

### DIFF
--- a/scripts/icub-grasp.xml
+++ b/scripts/icub-grasp.xml
@@ -55,7 +55,6 @@
         <dependencies>
             <port timeout="20">/icubSim/torso/state:o</port>
             <port timeout="20">/icubSim/head/state:o</port>
-            <port timeout="20">/icubSim/inertial</port>
         </dependencies>
         <ensure>
             <wait when="stop">5</wait>


### PR DESCRIPTION
`/icubSim/inertial` has been deprecated in https://github.com/robotology/icub-models-generator/pull/231.

At any rate, `iKinGazeCtrl` doesn't use the inertial sensor in simulation mode.